### PR TITLE
GTAPI-15: Reverse filter logic

### DIFF
--- a/API/GoTravel.API.Domain/Services/IStopPointService.cs
+++ b/API/GoTravel.API.Domain/Services/IStopPointService.cs
@@ -11,7 +11,7 @@ public interface IStopPointService
     /// <param name="nameQuery">The search query</param>
     /// <param name="maxResults">Maximum number of results to return, defaults to 25</param>
     /// <param name="lineModeFilters">Filters the results by the given line modes</param>
-    public Task<ICollection<StopPointBaseDto>> GetStopPointsByNameAsync(string nameQuery, ICollection<string> lineModeFilters, int maxResults = 25, CancellationToken ct = default);
+    public Task<ICollection<StopPointBaseDto>> GetStopPointsByNameAsync(string nameQuery, ICollection<string> hiddenLineModes, int maxResults = 25, CancellationToken ct = default);
     
     /// <summary>
     /// Returns a list of stop points within a radius of a given point.
@@ -22,7 +22,7 @@ public interface IStopPointService
     /// <param name="maxResults">Maximum number of results to return, defaults to 25</param>
     /// <param name="lineModeFilters">Filters the results by the given line modes</param>
     /// <param name="ct"></param>
-    public Task<ICollection<StopPointBaseDto>> GetStopPointsAroundPointAsync(float latitude, float longitude, ICollection<string> lineModeFilters, int radius = 850, int maxResults = 25, CancellationToken ct = default);
+    public Task<ICollection<StopPointBaseDto>> GetStopPointsAroundPointAsync(float latitude, float longitude, ICollection<string> hiddenLineModes, int radius = 850, int maxResults = 25, CancellationToken ct = default);
     
     public Task<ICollection<StopPointBaseDto>> GetStopPointChildrenAsync(StopPointBaseDto stopPoint, CancellationToken ct = default);
  }

--- a/API/GoTravel.API.Services/Services/StopPointService.cs
+++ b/API/GoTravel.API.Services/Services/StopPointService.cs
@@ -18,7 +18,7 @@ public class StopPointService: IStopPointService
         _mapper = mapper;
     }
     
-    public async Task<ICollection<StopPointBaseDto>> GetStopPointsByNameAsync(string nameQuery, ICollection<string> filterLineModes, int maxResults = 25, CancellationToken ct = default)
+    public async Task<ICollection<StopPointBaseDto>> GetStopPointsByNameAsync(string nameQuery, ICollection<string> hiddenLineModes, int maxResults = 25, CancellationToken ct = default)
     {
         var results = await _repo.GetStopPoints(nameQuery, maxResults, ct);
 
@@ -28,15 +28,15 @@ public class StopPointService: IStopPointService
             stop.Children = await GetStopPointChildrenAsync(stop, ct);
         }
         
-        if (filterLineModes.Any())
+        if (hiddenLineModes.Any())
         {
-            mapped = FilterLineModes(mapped, filterLineModes).ToList();
+            mapped = FilterLineModes(mapped, hiddenLineModes).ToList();
         }
 
         return mapped;
     }
 
-    public async Task<ICollection<StopPointBaseDto>> GetStopPointsAroundPointAsync(float latitude, float longitude, ICollection<string> filterLineModes = null, int radius = 850, int maxResults = 25, CancellationToken ct = default)
+    public async Task<ICollection<StopPointBaseDto>> GetStopPointsAroundPointAsync(float latitude, float longitude, ICollection<string> hiddenLineModes = null, int radius = 850, int maxResults = 25, CancellationToken ct = default)
     {
         var searchAroundPoint = new Point(longitude, latitude);
         var results = await _repo.GetStopPoints(searchAroundPoint, radius, maxResults, ct);
@@ -47,9 +47,9 @@ public class StopPointService: IStopPointService
             stop.Children = await GetStopPointChildrenAsync(stop, ct);
         }
 
-        if (filterLineModes.Any())
+        if (hiddenLineModes.Any())
         {
-            mapped = FilterLineModes(mapped, filterLineModes).ToList();
+            mapped = FilterLineModes(mapped, hiddenLineModes).ToList();
         }
 
         return mapped;
@@ -69,15 +69,15 @@ public class StopPointService: IStopPointService
     }
 
     /// <summary>
-    /// Removes any line modes that are not in the filterLineModes list.
+    /// Removes any line modes in the hiddenLineModes list.
     /// Removes any stop points that have no line modes left after filtering.
     /// </summary>
-    private static IEnumerable<StopPointBaseDto> FilterLineModes(ICollection<StopPointBaseDto> stopPoints, ICollection<string> filterLineModes)
+    private static IEnumerable<StopPointBaseDto> FilterLineModes(ICollection<StopPointBaseDto> stopPoints, ICollection<string> hiddenLineModes)
     {
         foreach (var stopPoint in stopPoints)
         {
-            stopPoint.LineModes = stopPoint.LineModes.Where(lm => filterLineModes.Contains(lm.LineModeName)).ToList();
-            stopPoint.Children = FilterLineModes(stopPoint.Children, filterLineModes).ToList();
+            stopPoint.LineModes = stopPoint.LineModes.Where(lm => !hiddenLineModes.Contains(lm.LineModeName)).ToList();
+            stopPoint.Children = FilterLineModes(stopPoint.Children, hiddenLineModes).ToList();
         }
 
         return stopPoints.Where(s => s.LineModes.Any());

--- a/API/GoTravel.API/Controllers/StopPointController.cs
+++ b/API/GoTravel.API/Controllers/StopPointController.cs
@@ -23,11 +23,11 @@ public class StopPointController: ControllerBase
     [ProducesResponseType(typeof(ICollection<StopPointBaseDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> SearchByName(string searchQuery, [FromQuery] List<string> filterLineMode, [Range(1, 255)] int maxResults = 25, CancellationToken ct = default)
+    public async Task<IActionResult> SearchByName(string searchQuery, [FromQuery] List<string> hiddenLineModes, [Range(1, 255)] int maxResults = 25, CancellationToken ct = default)
     {
         try
         {
-            var results = await _stopPointService.GetStopPointsByNameAsync(searchQuery, filterLineMode, maxResults, ct);
+            var results = await _stopPointService.GetStopPointsByNameAsync(searchQuery, hiddenLineModes, maxResults, ct);
             return Ok(results);
         }
         catch (ArgumentException e)
@@ -46,11 +46,11 @@ public class StopPointController: ControllerBase
     [ProducesResponseType(typeof(ICollection<StopPointBaseDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> SearchAroundPoint(float lat, float lon, [FromQuery] List<string> filterLineMode, [Range(1, 10000)] int radius = 850, [Range(1, 255)] int maxResults = 25, CancellationToken ct = default)
+    public async Task<IActionResult> SearchAroundPoint(float lat, float lon, [FromQuery] List<string> hiddenLineModes, [Range(1, 10000)] int radius = 850, [Range(1, 255)] int maxResults = 25, CancellationToken ct = default)
     {
         try
         {
-            var results = await _stopPointService.GetStopPointsAroundPointAsync(lat, lon, filterLineMode, radius, maxResults, ct);
+            var results = await _stopPointService.GetStopPointsAroundPointAsync(lat, lon, hiddenLineModes, radius, maxResults, ct);
             return Ok(results);
         }
         catch (ArgumentException e)

--- a/Tests/GoTravel.API.UnitTests/Services/StopPointServiceUnitTests.cs
+++ b/Tests/GoTravel.API.UnitTests/Services/StopPointServiceUnitTests.cs
@@ -75,10 +75,10 @@ public class StopPointServiceUnitTests
     }
 
     [Test]
-    public async Task SearchStopPoint_Filters_ByLineMode()
+    public async Task SearchStopPoint_FiltersOut_ByLineMode()
     {
         // Arrange
-        var filters = new List<string> { "LINE MODE 3" };
+        var hiddenLineModes = new List<string> { "LINE MODE 3" };
         _mockRepo.Setup(x => x.GetStopPoints(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<GLStopPoint>()
             {
@@ -104,6 +104,22 @@ public class StopPointServiceUnitTests
                                     LineModeName = "LINE MODE 3"
                                 }
                             }
+                        },
+                        new()
+                        {
+                            StopPointId = "1",
+                            IsEnabled = true,
+                            LineId = "Line 2",
+                            Line = new()
+                            {
+                                IsEnabled = true,
+                                LineId = "2",
+                                LineMode = new()
+                                {
+                                    IsEnabled = true,
+                                    LineModeName = "LINE MODE 2"
+                                }
+                            }
                         }
                     }
                 }
@@ -113,7 +129,7 @@ public class StopPointServiceUnitTests
             .ReturnsAsync(new List<GLStopPoint>());
         
         // Act
-        var result = await _sut.GetStopPointsByNameAsync("Stop", filters);
+        var result = await _sut.GetStopPointsByNameAsync("Stop", hiddenLineModes);
         
         // Assert
         Assert.That(result, Is.Not.Null);


### PR DESCRIPTION
Reverses the filter logic on stop point searches, so clients specify 'hidden' line modes rather than opting in